### PR TITLE
予約・予約削除における日時ポリシーの修正

### DIFF
--- a/src/components/MyReservationCard.tsx
+++ b/src/components/MyReservationCard.tsx
@@ -21,6 +21,7 @@ export const MyReservationCard = ({
   }) => void;
   my_user_id?: string;
 }) => {
+  const now_date = new Date();
   return (
     <div
       key={key}
@@ -48,10 +49,10 @@ export const MyReservationCard = ({
                       {reservation_slot_index + 1}限:{" "}
                     </span>
                     {reservation_slot.map((reservation, reservation_index) => {
+                      // 過去の予約は削除できない
                       const deletable =
                         reservation.user?.user_id === my_user_id &&
-                        reservation.date.getTime() - new Date().getTime() >
-                          1000 * 60 * 60 * 24 * 3;
+                        reservation.date.getTime() - now_date.getTime() > 0;
                       return (
                         <div
                           key={reservation_index}

--- a/src/components/ReservationCard.tsx
+++ b/src/components/ReservationCard.tsx
@@ -24,6 +24,8 @@ export const ReservationCard = ({
     [onClickReservationSlotArg]
   );
 
+  const now_date = new Date();
+
   return (
     <div
       key={key}
@@ -36,9 +38,9 @@ export const ReservationCard = ({
       <div>
         {table_data.reservation_slots.map(
           (reservation_slot, reservation_slot_index) => {
-            // 過去と当日は予約できない
+            // 過去は予約できない
             const creatable =
-              table_data.date.getTime() - new Date().getTime() > 0;
+              table_data.date.getTime() - now_date.getTime() > 0;
             return (
               <div
                 key={reservation_slot_index}


### PR DESCRIPTION
## 背景

- 予約削除は3日前まで可能となっていたが、当日以降であれば可能にしてほしい要望
- 予約作成についても当日以降であれば可能にしてほしい要望

## 機能変更

- 予約削除の制限変更
- 予約作成の制限変更

できるだけコードの記法は揃えるようにした